### PR TITLE
fixed old behavior of expanding first item if no one is marked

### DIFF
--- a/src/Accordion.php
+++ b/src/Accordion.php
@@ -134,7 +134,10 @@ class Accordion extends Widget
     {
         $items = [];
         $index = 0;
-        $expanded = array_search(true, ArrayHelper::getColumn($this->items, 'expand', true));
+        $expanded = array_search(true, ArrayHelper::getColumn(ArrayHelper::toArray($this->items), 'expand', true));
+        if ($expanded === false) {
+            $expanded = current(array_keys($this->items));
+        }
         foreach ($this->items as $key => $item) {
             if (!is_array($item)) {
                 $item = ['content' => $item];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️ 
| New feature?  | ❌ 
| Breaks BC?    | ❌ 
| Tests pass?   | ✔️ 
| Fixed issues  | https://github.com/yiisoft/yii2-bootstrap4/pull/196, https://github.com/yiisoft/yii2-bootstrap4/issues/158

I produced a BC break with the previous pull request I fixed with this one
